### PR TITLE
feat: add bot trigger system with custom instruction support

### DIFF
--- a/bot_trigger.py
+++ b/bot_trigger.py
@@ -1,0 +1,45 @@
+import asyncio
+from src.bots.review_bot import ReviewBot
+from src.bots.fix_bot import FixBot
+
+async def trigger_bot(bot_name: str, instruction: str, repo_name: str = None, pr_number: int = None):
+    """
+    Trigger a specific bot with custom instruction
+    
+    Args:
+        bot_name: "review" or "fix"
+        instruction: Custom instruction for the bot
+        repo_name: GitHub repo (format: "owner/repo")
+        pr_number: PR number to process
+    
+    Returns:
+        dict: Result of bot execution
+    """
+    try:
+        if bot_name.lower() == "review":
+            bot = ReviewBot()
+            if repo_name and pr_number:
+                result = await bot.review_pr(repo_name, pr_number, custom_instruction=instruction)
+            else:
+                result = {"error": "ReviewBot requires repo_name and pr_number"}
+        
+        elif bot_name.lower() == "fix":
+            bot = FixBot()
+            if repo_name and pr_number:
+                # Get existing review comments and apply custom instruction
+                result = await bot.fix_code(repo_name, pr_number, [instruction], custom_instruction=instruction)
+            else:
+                result = {"error": "FixBot requires repo_name and pr_number"}
+        
+        else:
+            result = {"error": f"Unknown bot: {bot_name}. Use 'review' or 'fix'"}
+        
+        return {"bot": bot_name, "instruction": instruction, "result": result}
+    
+    except Exception as e:
+        return {"error": f"Bot trigger failed: {str(e)}"}
+
+# Sync wrapper for non-async environments
+def run_bot(bot_name: str, instruction: str, repo_name: str = None, pr_number: int = None):
+    """Synchronous wrapper for trigger_bot"""
+    return asyncio.run(trigger_bot(bot_name, instruction, repo_name, pr_number))


### PR DESCRIPTION
- Add trigger_bot() function to programmatically run ReviewBot and FixBot
- Support custom instructions for both bots to guide AI behavior
- Include sync wrapper run_bot() for non-async environments
- Update ReviewBot and FixBot to accept and use custom instructions