### PR TITLE
feat: enhance FixBot with confidence scoring and direct mention support

### DIFF
--- a/src/bots/fix_bot.py
+++ b/src/bots/fix_bot.py
@@ -20,21 +20,23 @@ class FixBot:
             fixes_applied = []
             
             for comment in review_comments:
-                if isinstance(comment, str) and "🤖" in comment:
-                    # Skip AI Summary - only process file-specific reviews
-                    if "AI Summary:" in comment:
-                        continue
-                    
-                    # Use AI to decide if this comment needs a fix
-                    needs_fix = await self._ai_should_fix(comment)
-                    if needs_fix:
+                if isinstance(comment, str):
+                    # Process both ReviewBot comments and direct FixBot mentions
+                    if "🤖" in comment:
+                        # Skip AI Summary - only process file-specific reviews
+                        if "AI Summary:" in comment:
+                            continue
                         fix_result = await self._create_suggested_fix(repo, pr, comment, custom_instruction)
-                        if fix_result and "Created suggested change" in fix_result:
-                            fixes_applied.append(fix_result)
+                    else:
+                        # Handle direct FixBot mentions - analyze the entire PR
+                        fix_result = await self._analyze_pr_for_fixes(repo, pr, comment, custom_instruction)
+                    
+                    if fix_result and "Created" in fix_result:
+                        fixes_applied.append(fix_result)
             
             if not fixes_applied:
                 # Post positive feedback when no fixes are needed
-                pr.create_issue_comment("✅ **FixBot - Code looks good!**\n\nNo issues found that require fixes. Great work!")
+                pr.create_issue_comment("🤖 **FixBot** ✅\n\nCode looks good! No issues found that require fixes. Great work!\n\n*Powered by AI Code Review System*")
                 return ["No fixes needed - posted positive feedback"]
             
             return fixes_applied
@@ -73,39 +75,59 @@ class FixBot:
             if not file_patch:
                 return f"Could not find changes for {filename}"
             
-            # Generate fix with AI
-            base_prompt = f"""Fix the changed lines in this diff:
-
-Review: {review_comment}
-Diff: {file_patch}
-
-Provide only the fixed code lines."""
+            # Generate multiple targeted fixes with confidence scores
+            fixes = await self._generate_partial_fixes(review_comment, file_patch, custom_instruction)
             
-            if custom_instruction:
-                prompt = f"{base_prompt}\n\nAdditional instruction: {custom_instruction}"
-            else:
-                prompt = base_prompt
+            # Show all fixes with confidence scores, create suggestions for high-confidence ones
+            suggestions_created = 0
+            low_confidence_fixes = []
+            
+            for i, fix in enumerate(fixes):
+                confidence_emoji = "🟢" if fix['confidence'] >= 0.9 else "🟡" if fix['confidence'] >= 0.7 else "🔴"
                 
-            fixed_code = self._call_falcon_ai(prompt)
-            
-            if "API error" in fixed_code or "failed" in fixed_code:
-                fixed_code = "# TODO: Address code review feedback"
-            
-            # Create suggested change
-            pr.create_review_comment(
-                body=f"""🔧 **FixBot Suggestion**
+                if fix['confidence'] >= 0.7:  # Create suggestions for high-confidence fixes
+                    # Add acceptance guidance based on confidence
+                    if fix['confidence'] >= 0.9:
+                        guidance = "✅ **Recommended** - High confidence, safe to apply"
+                    elif fix['confidence'] >= 0.8:
+                        guidance = "⚠️ **Review suggested** - Good confidence, please verify"
+                    else:
+                        guidance = "🔍 **Manual review required** - Moderate confidence, check carefully"
+                    
+                    pr.create_review_comment(
+                        body=f"""🔧 **FixBot Suggestion #{i+1}** {confidence_emoji}
 
 ```suggestion
-{fixed_code}
+{fix['code']}
 ```
 
+**Confidence:** {fix['confidence']:.0%} | **Issue:** {fix['issue']}
+
+{guidance}
+
 *Click "Apply suggestion" to commit this fix.*""",
-                commit=pr.head.sha,
-                path=filename,
-                line=self._get_line_from_patch(file_patch)
-            )
+                        commit=pr.head.sha,
+                        path=filename,
+                        line=fix.get('line', self._get_line_from_patch(file_patch))
+                    )
+                    suggestions_created += 1
+                else:
+                    # Track low-confidence fixes to show in summary
+                    low_confidence_fixes.append(f"• {fix['issue']} (Confidence: {fix['confidence']:.0%})")
             
-            return f"Created suggested change for {filename}"
+            # Post summary comment showing all confidence scores
+            if suggestions_created > 0 or low_confidence_fixes:
+                summary_parts = []
+                if suggestions_created > 0:
+                    summary_parts.append(f"✅ Created {suggestions_created} high-confidence suggestions")
+                if low_confidence_fixes:
+                    summary_parts.append(f"⚠️ Low-confidence issues detected:\n" + "\n".join(low_confidence_fixes))
+                
+                pr.create_issue_comment(f"🤖 **FixBot Analysis for {filename}**\n\n" + "\n\n".join(summary_parts))
+            
+            return f"Analyzed {filename}: {suggestions_created} suggestions created, {len(low_confidence_fixes)} low-confidence issues"
+            
+
         except Exception as e:
             return f"Error: {str(e)}"
     
@@ -147,6 +169,79 @@ Respond with only "YES" if the comment identifies specific issues that need code
         except Exception:
             # Fallback to conservative approach - assume fix is needed
             return True
+    
+    async def _generate_partial_fixes(self, review_comment: str, file_patch: str, custom_instruction: str = None) -> list:
+        """Generate multiple targeted fixes with confidence scores"""
+        base_prompt = f"""Analyze this code review and create targeted fixes:
+
+Review: {review_comment}
+Diff: {file_patch}
+
+Provide response as JSON array with format:
+[
+  {{
+    "issue": "Brief description of issue",
+    "code": "Fixed code lines",
+    "confidence": 0.95,
+    "line": 10
+  }}
+]
+
+Create separate fixes for different issues. Confidence: 0.0-1.0 scale."""
+        
+        if custom_instruction:
+            prompt = f"{base_prompt}\n\nAdditional instruction: {custom_instruction}"
+        else:
+            prompt = base_prompt
+            
+        try:
+            response = self._call_falcon_ai(prompt)
+            
+            # Try to parse JSON response
+            import json
+            fixes = json.loads(response)
+            
+            # Validate and clean fixes
+            valid_fixes = []
+            for fix in fixes:
+                if isinstance(fix, dict) and 'code' in fix and 'confidence' in fix:
+                    valid_fixes.append({
+                        'issue': fix.get('issue', 'Code improvement'),
+                        'code': fix['code'].strip(),
+                        'confidence': min(max(fix['confidence'], 0.0), 1.0),
+                        'line': fix.get('line')
+                    })
+            
+            return valid_fixes[:3]  # Limit to 3 suggestions max
+            
+        except Exception:
+            # Fallback to single fix
+            return [{
+                'issue': 'Code improvement',
+                'code': '# TODO: Address code review feedback',
+                'confidence': 0.5
+            }]
+    
+    async def _analyze_pr_for_fixes(self, repo, pr, instruction: str, custom_instruction: str = None):
+        """Analyze entire PR for fixes when directly mentioned"""
+        try:
+            # Get all changed files
+            files = list(pr.get_files())
+            fixes_created = 0
+            
+            for file in files:
+                if file.patch and any(file.filename.endswith(ext) for ext in ['.py', '.js', '.ts', '.java', '.cpp', '.go']):
+                    # Create a synthetic review comment for this file
+                    synthetic_review = f"🤖 {file.filename}: {instruction}"
+                    
+                    fix_result = await self._create_suggested_fix(repo, pr, synthetic_review, custom_instruction)
+                    if fix_result and "suggestions created" in fix_result:
+                        fixes_created += 1
+            
+            return f"Analyzed PR: processed {fixes_created} files" if fixes_created > 0 else "No fixable issues found in PR"
+            
+        except Exception as e:
+            return f"Error analyzing PR: {str(e)}"
     
     def _get_line_from_patch(self, patch: str) -> int:
         """Extract line number from patch"""


### PR DESCRIPTION
- Add partial fixes with multiple targeted suggestions per issue
- Show confidence scores (🟢🟡🔴) with acceptance guidance
- Support direct @fixbot mentions to analyze entire PR
- Display low-confidence issues in summary without creating suggestions